### PR TITLE
Error on unsatisfiable range

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,22 +64,25 @@ Store.prototype._read = function (offset, length, cb) {
   cb = once(cb)
   var buffers = []
   self._store('readonly', function (err, store) {
-    if (err) return cb(err)
-    var offsets = self._blocks(offset, offset+length)
-    var pending = offsets.length + 1
-    var firstBlock = offsets.length > 0 ? offsets[0].block : 0
-    var j = 0
-    for (var i = 0; i < offsets.length; i++) (function (o) {
-      var key = self.name + DELIM + o.block
-      backify(store.get(key), function (err, ev) {
-        if (err) return cb(err)
-        buffers[o.block-firstBlock] = ev.target.result
-          ? bufferFrom(ev.target.result.subarray(o.start,o.end))
-          : bufferAlloc(o.end-o.start)
-        if (--pending === 0) cb(null, Buffer.concat(buffers))
-      })
-    })(offsets[i])
-    if (--pending === 0) cb(null, Buffer.concat(buffers))
+    backify(store.get(self.name + DELIM + "length"), function(err, ev) {
+      if ((ev.target.result || 0) < offset+length) return cb(new Error('Could not satisfy length'))
+      if (err) return cb(err)
+      var offsets = self._blocks(offset, offset+length)
+      var pending = offsets.length + 1
+      var firstBlock = offsets.length > 0 ? offsets[0].block : 0
+      var j = 0
+      for (var i = 0; i < offsets.length; i++) (function (o) {
+        var key = self.name + DELIM + o.block
+        backify(store.get(key), function (err, ev) {
+          if (err) return cb(err)
+          buffers[o.block-firstBlock] = ev.target.result
+            ? bufferFrom(ev.target.result.subarray(o.start,o.end))
+            : bufferAlloc(o.end-o.start)
+          if (--pending === 0) cb(null, Buffer.concat(buffers))
+        })
+      })(offsets[i])
+      if (--pending === 0) cb(null, Buffer.concat(buffers))
+    })
   })
 }
 
@@ -116,8 +119,10 @@ Store.prototype._write = function (offset, buf, cb) {
       store.put(block,self.name + DELIM + o.block)
       j += len
     }
-    store.transaction.addEventListener('complete', function () {
-      self.length = Math.max(self.length, offset + buf.length)
+    var length = Math.max(self.length || 0, offset + buf.length)
+    store.put(length, self.name + DELIM + "length")
+      store.transaction.addEventListener('complete', function () {
+      self.length = length
       cb(null)
     })
     store.transaction.addEventListener('error', cb)

--- a/test/random.js
+++ b/test/random.js
@@ -41,22 +41,27 @@ test.only('random', function (t) {
 
   function read (i) {
     if (i === nreads) return 
-    var offset = Math.floor(Math.random() * 5000)
+    var offset = Math.floor(Math.random() * 6500) // 15% error rate, due to offset or length running past end of file
     var len = Math.floor(Math.random()*1000)
     var pending = 2, data = { mstore: null, istore: null }
     istore.read(offset, len, function (err, buf) {
-      t.ifError(err)
+      data.ierr = err
       data.istore = buf
       if (--pending === 0) check()
     })
     mstore.read(offset, len, function (err, buf) {
-      t.ifError(err)
+      data.merr = err
       data.mstore = buf
       if (--pending === 0) check()
     })
     function check () {
-      t.ok(bequal(data.istore, data.mstore),
-        'read: offset=' + offset + ', length=' + len)
+      if (data.merr || data.ierr) {
+        t.ok((data.ierr && data.merr),
+          'read: offset=' + offset + ', length=' + len)
+      } else {
+        t.ok(bequal(data.istore, data.mstore),
+          'read: offset=' + offset + ', length=' + len)
+      }
       read(i+1)
     }
   }


### PR DESCRIPTION
This PR matches up behaviour with random-access-memory when reading past the end of the "file". This is required for hypercore to reliably detect when no key has been stored (RAM and RAI diverge in that the former returns an error, whereas the latter returns no error and an array of 0 bytes)