### PR TITLE
Fix block buffer when chunking

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ Store.prototype._write = function (req) {
       var o = offsets[i]
       var len = o.end - o.start
       if (len === self.size) {
-        block = req.data.slice(j,j+len)
+        block = bufferFrom(req.data.slice(j, j+len))
       } else {
         block = buffers[i]
         req.data.copy(block, o.start, j, j+len)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "random-access-storage": "^1.3.0"
   },
   "devDependencies": {
+    "browser-run": "^5.0.1",
+    "browserify": "^16.2.3",
     "buffer-equals": "^1.0.4",
+    "random-access-memory": "^3.1.1",
     "randombytes": "^2.0.5",
     "tape": "^4.6.3"
   },


### PR DESCRIPTION
`req.data.slice` returns a `new Buffer that references the same memory as the original` (https://nodejs.org/api/buffer.html#buffer_buf_slice_start_end).

So when we call `store.put`, we actually store into indexeddb the block, plus the original buffer. (the property `block.buffer` will be a copy of the original buffer).

A simple example:
```js
  var cool = random('cool.txt', { size: 1 }) // size of 1
  cool.write(0, Buffer.from('abc'), function (err) {
    // actually, 3 blocks will be created, one for each character
    // but each block will also have a buffer propery, which
    // is a full copy of the original buffer.
    // So we actually store 3 x the original buffer size
  })
```

without this patch, writing big buffers can crash the browser, and space used to store the idb grows really quick (original buffer size is added to each block size)